### PR TITLE
GitHub: build docker image automatically on tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Docker image build
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  DOCKER_REPO: lightninglabs
+  DOCKER_IMAGE: lndinit
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: lightninglabs/gh-actions/setup-qemu-action@39555064b3ae5c6d5c71a8ab304355faeaf3f4d4
+
+      - name: Set up Docker Buildx
+        uses: lightninglabs/gh-actions/setup-buildx-action@39555064b3ae5c6d5c71a8ab304355faeaf3f4d4
+
+      - name: Login to DockerHub
+        uses: lightninglabs/gh-actions/login-action@39555064b3ae5c6d5c71a8ab304355faeaf3f4d4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_API_KEY }}
+
+      - name: Set env for RELEASE_VERSION
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      # We will push tags with the format v0.x.y-lnd-v0.aa.bb-beta where x and y
+      # are lndinit's version and aa and bb are lnd's version. This variable
+      # LND_VERSION extracts everything after v0.x.y-lnd- so we know which base
+      # image we need to build on top of.
+      - name: Set env for LND_VERSION
+        run: echo "LND_VERSION=${RELEASE_VERSION##v*\.*\.*-lnd-}" >> $GITHUB_ENV
+
+      - name: Build and push
+        id: docker_build
+        uses: lightninglabs/gh-actions/build-push-action@39555064b3ae5c6d5c71a8ab304355faeaf3f4d4
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
+          build-args: checkout=${{ env.RELEASE_VERSION }} BASE_IMAGE_VERSION=${{ env.LND_VERSION }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
We will push tags with the format v0.x.y-lnd-v0.aa.bb-beta where x and y
are lndinit's version and aa and bb are lnd's version. The GitHub
workflow then splits those values apart and builds the docker image
accordingly, using the specified lnd version as the base image.
