### PR TITLE
Support standalone binary release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker image build
 on:
   push:
     tags:
-      - 'v*'
+      - 'docker/v*'
 
 defaults:
   run:
@@ -30,12 +30,12 @@ jobs:
           password: ${{ secrets.DOCKER_API_KEY }}
 
       - name: Set env for RELEASE_VERSION
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/docker}" >> $GITHUB_ENV
 
-      # We will push tags with the format v0.x.y-lnd-v0.aa.bb-beta where x and y
-      # are lndinit's version and aa and bb are lnd's version. This variable
-      # LND_VERSION extracts everything after v0.x.y-lnd- so we know which base
-      # image we need to build on top of.
+      # We will push tags with the format docker/v0.x.y-lnd-v0.aa.bb-beta where
+      # x and y are lndinit's version and aa and bb are lnd's version. This
+      # variable LND_VERSION extracts everything after v0.x.y-lnd- so we know
+      # which base image we need to build on top of.
       - name: Set env for LND_VERSION
         run: echo "LND_VERSION=${RELEASE_VERSION##v*\.*\.*-lnd-}" >> $GITHUB_ENV
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Set env for RELEASE_VERSION
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/docker}" >> $GITHUB_ENV
 
-      # We will push tags with the format docker/v0.x.y-lnd-v0.aa.bb-beta where
-      # x and y are lndinit's version and aa and bb are lnd's version. This
-      # variable LND_VERSION extracts everything after v0.x.y-lnd- so we know
-      # which base image we need to build on top of.
+      # We will push tags with the format docker/v0.x.y-beta-lnd-v0.aa.bb-beta
+      # where x and y are lndinit's version and aa and bb are lnd's version.
+      # This variable LND_VERSION extracts everything after v0.x.y-lnd- so we
+      # know which base image we need to build on top of.
       - name: Set env for LND_VERSION
-        run: echo "LND_VERSION=${RELEASE_VERSION##v*\.*\.*-lnd-}" >> $GITHUB_ENV
+        run: echo "LND_VERSION=${RELEASE_VERSION##v*\.*\.*-beta-lnd-}" >> $GITHUB_ENV
 
       - name: Build and push
         id: docker_build

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ _testmain.go
 /lndinit
 /lndinit-debug
 
+lndinit-v*/
+
 *.key
 *.hex
 

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Simple bash script to build basic lndinit for all the platforms we support
+# with the golang cross-compiler.
+#
+# Copyright (c) 2016 Company 0, LLC.
+# Use of this source code is governed by the ISC
+# license.
+
+set -e
+
+PKG="github.com/lightninglabs/lndinit"
+PACKAGE=lndinit
+
+# green prints one line of green text (if the terminal supports it).
+function green() {
+  echo -e "\e[0;32m${1}\e[0m"
+}
+
+# red prints one line of red text (if the terminal supports it).
+function red() {
+  echo -e "\e[0;31m${1}\e[0m"
+}
+
+# build_release builds the actual release binaries.
+#   arguments: <version-tag> <build-system(s)> <ldflags>
+function build_release() {
+  local tag=$1
+  local sys=$2
+  local ldflags=$3
+
+  green " - Packaging vendor"
+  go mod vendor
+  tar -czf vendor.tar.gz vendor
+
+  maindir=$PACKAGE-$tag
+  mkdir -p $maindir
+
+  cp vendor.tar.gz $maindir/
+  rm vendor.tar.gz
+  rm -r vendor
+
+  package_source="${maindir}/${PACKAGE}-source-${tag}.tar"
+  git archive -o "${package_source}" HEAD
+  gzip -f "${package_source}" >"${package_source}.gz"
+
+  cd "${maindir}"
+
+  for i in $sys; do
+    os=$(echo $i | cut -f1 -d-)
+    arch=$(echo $i | cut -f2 -d-)
+    arm=
+
+    if [[ $arch == "armv6" ]]; then
+      arch=arm
+      arm=6
+    elif [[ $arch == "armv7" ]]; then
+      arch=arm
+      arm=7
+    fi
+
+    dir="${PACKAGE}-${i}-${tag}"
+    mkdir "${dir}"
+    pushd "${dir}"
+
+    green " - Building: ${os} ${arch} ${arm}"
+    env CGO_ENABLED=0 GOOS=$os GOARCH=$arch GOARM=$arm go build -v -trimpath -ldflags="${ldflags}" ${PKG}
+    popd
+
+    if [[ $os == "windows" ]]; then
+      zip -r "${dir}.zip" "${dir}"
+    else
+      tar -cvzf "${dir}.tar.gz" "${dir}"
+    fi
+
+    rm -r "${dir}"
+  done
+
+  shasum -a 256 * >manifest-$tag.txt
+}
+
+# usage prints the usage of the whole script.
+function usage() {
+  red "Usage: "
+  red "release.sh build-release <version-tag> <build-system(s)> <ldflags>"
+}
+
+# Whatever sub command is passed in, we need at least 2 arguments.
+if [ "$#" -lt 2 ]; then
+  usage
+  exit 1
+fi
+
+# Extract the sub command and remove it from the list of parameters by shifting
+# them to the left.
+SUBCOMMAND=$1
+shift
+
+# Call the function corresponding to the specified sub command or print the
+# usage if the sub command was not found.
+case $SUBCOMMAND in
+build-release)
+  green "Building release"
+  build_release "$@"
+  ;;
+*)
+  usage
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
With this PR we add the `make release tag=v0.x.y-beta` command to the Makefile.

To make the version tags easier to understand, we now expect two kinds of tags to be pushed whenever we bump the version of `lndinit`:
 - `v0.x.y-beta`: For the standalone binary release
 - `docker/v0.x.y-beta-lnd-v0.aa.bb-beta`: For building a docker image that contains `lndinit` and `lnd` with their respective versions.

That way we can push a new tag (for example `docker/v0.1.2-beta-lnd-v0.15.0-beta`) to build a new docker image for a new base `lnd` version without needing to change any code.