### PR TITLE
store-secret: read up to EOF from stdin

### DIFF
--- a/cmd_store_secret.go
+++ b/cmd_store_secret.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -83,7 +84,7 @@ func (x *storeSecretCommand) Execute(args []string) error {
 	default:
 		log("Reading secret from stdin")
 		secret, err := bufio.NewReader(os.Stdin).ReadString('\n')
-		if err != nil {
+		if err != nil && err != io.EOF {
 			return fmt.Errorf("error reading secret from stdin: %v",
 				err)
 		}

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.17.6
 ARG BASE_IMAGE=lightninglabs/lnd
-ARG BASE_IMAGE_VERSION=0.14.2-beta
+ARG BASE_IMAGE_VERSION=v0.14.2-beta
 
 FROM golang:${GO_VERSION}-alpine as builder
 

--- a/version.go
+++ b/version.go
@@ -32,7 +32,7 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 2
+	AppPatch uint = 3
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
I should have tested everything on an actual cluster before merging #4 :see_no_evil:
Unfortunately the interaction with k8s is a bit tricky to test in unit tests, so we don't have all functionality covered yet. But I'll look into ways of simulating a k8s backend so we can add more unit tests.

I now manually built and deployed this version on a cluster and made sure everything works!