### PR TITLE
github: create a daily build from master and lnd/daily-testing-only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'docker/v*'
+  schedule:
+    # Every day at 1AM (UTC).
+    - cron: '0 1 * * *'
 
 defaults:
   run:
@@ -41,6 +44,13 @@ jobs:
       
       - name: Set env for LNDINIT_VERSION
         run: echo "LNDINIT_VERSION=${RELEASE_VERSION%%-lnd-v*\.*\.*-beta}" >> $GITHUB_ENV
+
+      - name: Set daily tag
+        if: github.event.schedule == '0 1 * * *'
+        run: |
+          echo "LND_VERSION=daily-testing-only" >> $GITHUB_ENV
+          echo "LNDINIT_VERSION=main" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=daily-testing-$(date -u +%Y%m%d),${DOCKER_REPO}/${DOCKER_IMAGE}:daily-testing-only" >> $GITHUB_ENV
 
       - name: Build and push
         id: docker_build


### PR DESCRIPTION
This PR adds a daily docker image build at 1 AM (UTC) which builds from `main` of `lndinit` paired with `lnd/daily-testing-only`.