### PR TITLE
lnd:v0.14.3-beta + releash.sh path fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.17.6
 ARG BASE_IMAGE=lightninglabs/lnd
-ARG BASE_IMAGE_VERSION=v0.14.2-beta
+ARG BASE_IMAGE_VERSION=v0.14.3-beta
 
 FROM golang:${GO_VERSION}-alpine as builder
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ spec:
           # The lndinit image is an image based on the main lnd image that just
           # adds the lndinit binary to it. The tag name is simply:
           #   <lndinit-version>-lnd-<lnd-version>
-          image: lightninglabs/lndinit:v0.1.0-lnd-v0.14.2-beta
+          image: lightninglabs/lndinit:v0.1.0-lnd-v0.14.3-beta
           env:
             - name: WALLET_SECRET_NAME
               value: lnd-wallet-secret

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.17.6
 ARG BASE_IMAGE=lightninglabs/lnd
-ARG BASE_IMAGE_VERSION=v0.14.2-beta
+ARG BASE_IMAGE_VERSION=v0.14.3-beta
 
 FROM golang:${GO_VERSION}-alpine as builder
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/kkdai/bstream v1.0.0
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
-	github.com/lightningnetwork/lnd v0.14.2-beta
+	github.com/lightningnetwork/lnd v0.14.3-beta
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.38.0
 	k8s.io/api v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -521,8 +521,8 @@ github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display h1:RZJ8H4ueU/aQ
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display/go.mod h1:2oKOBU042GKFHrdbgGiKax4xVrFiZu51lhacUZQ9MnE=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20210520211913-522b799e65b1 h1:h1BsjPzWea790mAXISoiT/qr0JRcixTCDNLmjsDThSw=
 github.com/lightningnetwork/lightning-onion v1.0.2-0.20210520211913-522b799e65b1/go.mod h1:rigfi6Af/KqsF7Za0hOgcyq2PNH4AN70AaMRxcJkff4=
-github.com/lightningnetwork/lnd v0.14.2-beta h1:v5Xgf0HjgA+umoinNrihMSoAuy52tYQnxCzX0wFaRwQ=
-github.com/lightningnetwork/lnd v0.14.2-beta/go.mod h1:BKTR+jbfcyFwsOPb3m8HaM09YmZF/SsbWd5UTCgDZlo=
+github.com/lightningnetwork/lnd v0.14.3-beta h1:7qPvlQt6sHRGsKABsLTFI45KaprQT0t3wTmqkJoRkkk=
+github.com/lightningnetwork/lnd v0.14.3-beta/go.mod h1:BKTR+jbfcyFwsOPb3m8HaM09YmZF/SsbWd5UTCgDZlo=
 github.com/lightningnetwork/lnd/cert v1.1.0/go.mod h1:3MWXVLLPI0Mg0XETm9fT4N9Vyy/8qQLmaM5589bEggM=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.0 h1:/yfVAwtPmdx45aQBoXQImeY7sOIEr7IXlImRMBOZ7GQ=

--- a/release.sh
+++ b/release.sh
@@ -33,6 +33,7 @@ function build_release() {
   go mod vendor
   tar -czf vendor.tar.gz vendor
 
+  tag=$(echo "$tag" | sed 's/\//_/')
   maindir=$PACKAGE-$tag
   mkdir -p $maindir
 


### PR DESCRIPTION
This PR updates all `lnd` references to `v0.14.3-beta`.

I saw an existing tag but it looks like it still used some `0.14.2` components. When I updated the tag to the contents of this branch, `release.sh` encountered a path error due to the tag containing `docker/...`. I'm unsure if this happens during the github build, but replacing `/` in the tag with `_` allowed it to succeed. If this change is unnecessary, please let me know and I'll remove that commit.