### PR TITLE
github: fix LNDINIT_VERSION to also match LND RCs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo "LND_VERSION=${RELEASE_VERSION##v*\.*\.*-beta-lnd-}" >> $GITHUB_ENV
       
       - name: Set env for LNDINIT_VERSION
-        run: echo "LNDINIT_VERSION=${RELEASE_VERSION%%-lnd-v*\.*\.*-beta}" >> $GITHUB_ENV
+        run: echo "LNDINIT_VERSION=${RELEASE_VERSION%%-lnd-v*\.*\.*-beta*}" >> $GITHUB_ENV
 
       - name: Set daily tag
         if: github.event.schedule == '0 1 * * *'


### PR DESCRIPTION
One-character fix to allow the github workflow to also build LND release candidate images.