### PR TITLE
readme: update required RBAC permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ metadata:
 rules:
   - apiGroups: [ "" ]
     resources: [ "secrets" ]
-    verbs: [ "get", "list", "watch", "update" ]
+    verbs: [ "get", "list", "create", "watch", "update", "patch" ]
 
 
 ---


### PR DESCRIPTION
Adds the missing verbs `create` and `patch` to the example Role for secret management, as described in:
- https://github.com/lightningnetwork/lnd/discussions/7393