### PR TITLE
lnd: bump base image to v0.16.4-beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.20.3
 ARG BASE_IMAGE=lightninglabs/lnd
-ARG BASE_IMAGE_VERSION=v0.16.4-beta.rc1
+ARG BASE_IMAGE_VERSION=v0.16.4-beta
 
 FROM golang:${GO_VERSION}-alpine as builder
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.20.3
 ARG BASE_IMAGE=lightninglabs/lnd
-ARG BASE_IMAGE_VERSION=v0.16.4-beta.rc1
+ARG BASE_IMAGE_VERSION=v0.16.4-beta
 
 FROM golang:${GO_VERSION}-alpine as builder
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/kkdai/bstream v1.0.0
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display
-	github.com/lightningnetwork/lnd v0.16.4-beta.rc1
+	github.com/lightningnetwork/lnd v0.16.4-beta
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.41.0
 	k8s.io/api v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,8 @@ github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display h1:RZJ8H4ueU/aQ
 github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display/go.mod h1:2oKOBU042GKFHrdbgGiKax4xVrFiZu51lhacUZQ9MnE=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20221202012345-ca23184850a1 h1:Wm0g70gkcAu2pGpNZwfWPSVOY21j8IyYsNewwK4OkT4=
 github.com/lightningnetwork/lightning-onion v1.2.1-0.20221202012345-ca23184850a1/go.mod h1:7dDx73ApjEZA0kcknI799m2O5kkpfg4/gr7N092ojNo=
-github.com/lightningnetwork/lnd v0.16.4-beta.rc1 h1:L8ktsv1lM5esVtiOlEtOBqU1dCoDckbm0FkcketBskQ=
-github.com/lightningnetwork/lnd v0.16.4-beta.rc1/go.mod h1:sK9F98TpFuO/fjLCX4jEjc65qr2GZGs8IquVde1N46I=
+github.com/lightningnetwork/lnd v0.16.4-beta h1:St6QUzRCjOR6vc5JYZ56TdJ/OiYkAeKK+X2SD9crprI=
+github.com/lightningnetwork/lnd v0.16.4-beta/go.mod h1:sK9F98TpFuO/fjLCX4jEjc65qr2GZGs8IquVde1N46I=
 github.com/lightningnetwork/lnd/clock v1.0.1/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=
 github.com/lightningnetwork/lnd/clock v1.1.0 h1:/yfVAwtPmdx45aQBoXQImeY7sOIEr7IXlImRMBOZ7GQ=
 github.com/lightningnetwork/lnd/clock v1.1.0/go.mod h1:KnQudQ6w0IAMZi1SgvecLZQZ43ra2vpDNj7H/aasemg=

--- a/version.go
+++ b/version.go
@@ -32,7 +32,7 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 14
+	AppPatch uint = 15
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
All that's required to trigger new image builds is pushing a tag w/desired lnd version, but it seems weird to have dependencies on an RC, so this bumps all RC references to the final release (seems consistent w/commentary in the v0.16.2 PR).

After merging, the tag will still need to be pushed in order to trigger the image build:
```
# merge PR
git checkout main
git pull
git tag v0.1.15-beta
git tag docker/v0.1.15-beta-lnd-v0.16.4-beta
git push -u origin  v0.1.15-beta  docker/v0.1.15-beta-lnd-v0.16.4-beta
```

Feel free to close this if you feel it's unnecessary. Either way, it would be good to get the v0.16.4 docker tag pushed (`docker/v0.1.14-beta-lnd-v0.16.4-beta` if this PR is closed). 