### PR TITLE
cmd_migrate_db: use lnd package for disk size check

### DIFF
--- a/version.go
+++ b/version.go
@@ -32,7 +32,7 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 25
+	AppPatch uint = 26
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
The previous disk space check only supported Linux/Unix. But we also want to build binaries for Windows.
Luckily, we already have this functionality for all our supported platforms in the healthcheck package of lnd.