### PR TITLE
migration: default to sqlite and surface flag defaults in -h

### DIFF
--- a/cmd_migrate_db.go
+++ b/cmd_migrate_db.go
@@ -98,7 +98,7 @@ type migrateDBCommand struct {
 	PprofPort         int       `long:"pprof-port" description:"Enable pprof profiling on the specified port"`
 	ForceNewMigration bool      `long:"force-new-migration" description:"Force a new migration from the beginning of the source DB so the resume state will be discarded"`
 	ForceVerifyDB     bool      `long:"force-verify-db" description:"Force a verification verifies two already marked (tombstoned and already migrated) dbs to make sure that the source db equals the content of the destination db"`
-	ChunkSize         uint64    `long:"chunk-size" description:"Chunk size for the migration in bytes"`
+	ChunkSize         uint64    `long:"chunk-size" description:"Chunk size for the migration in bytes (default: 20971520, i.e. 20MB; max: 524288000, i.e. 500MB)"`
 }
 
 func newMigrateDBCommand() *migrateDBCommand {
@@ -112,7 +112,7 @@ func newMigrateDBCommand() *migrateDBCommand {
 			},
 		},
 		Dest: &DestDB{
-			Backend:  lncfg.PostgresBackend,
+			Backend:  lncfg.SqliteBackend,
 			Postgres: &postgres.Config{},
 			Sqlite: &Sqlite{
 				Config:   &sqlite.Config{},

--- a/docs/data-migration.md
+++ b/docs/data-migration.md
@@ -237,18 +237,18 @@ Help Options:
           --force-new-migration                       Force a new migration from the beginning of the source DB so the resume state will be discarded
           --force-verify-db                           Force a verification verifies two already marked (tombstoned and already migrated) dbs to make sure that the source db equals the
                                                       content of the destination db
-          --chunk-size=                               Chunk size for the migration in bytes
+          --chunk-size=                               Chunk size for the migration in bytes (default: 20971520, i.e. 20MB; max: 524288000, i.e. 500MB)
 
     source:
           --source.backend=[bolt]                     The source database backend. (default: bolt)
 
     bolt:
           --source.bolt.dbtimeout=                    Specify the timeout value used when opening the database. (default: 1m0s)
-          --source.bolt.data-dir=                     Lnd data dir where bolt dbs are located.
-          --source.bolt.tower-dir=                    Lnd watchtower dir where bolt dbs for the watchtower server are located.
+          --source.bolt.data-dir=                     Lnd data dir where bolt dbs are located. (default: ~/.lnd/data)
+          --source.bolt.tower-dir=                    Lnd watchtower dir where bolt dbs for the watchtower server are located. (default: ~/.lnd/data)
 
     dest:
-          --dest.backend=[postgres|sqlite]            The destination database backend. (default: postgres)
+          --dest.backend=[postgres|sqlite]            The destination database backend. (default: sqlite)
 
     postgres:
           --dest.postgres.dsn=                        Database connection string.
@@ -256,8 +256,8 @@ Help Options:
           --dest.postgres.maxconnections=             The maximum number of open connections to the database. Set to zero for unlimited.
 
     sqlite:
-          --dest.sqlite.data-dir=                     Lnd data dir where sqlite dbs are located.
-          --dest.sqlite.tower-dir=                    Lnd watchtower dir where sqlite dbs for the watchtower server are located.
+          --dest.sqlite.data-dir=                     Lnd data dir where sqlite dbs are located. (default: ~/.lnd/data)
+          --dest.sqlite.tower-dir=                    Lnd watchtower dir where sqlite dbs for the watchtower server are located. (default: ~/.lnd/data)
 
     sqlite-config:
           --dest.sqlite.sqlite-config.timeout=        The time after which a database query should be timed out.


### PR DESCRIPTION
## Summary

- Switched `--dest.backend` default from `postgres` to `sqlite` so users on a fresh box without a postgres server can run `lndinit migrate-db -n <network>` without an extra flag. Matches LND's planned default backend.
- Surfaced the `--chunk-size` default (20MB) and ceiling (500MB) in the flag description (the ceiling is enforced by `migratekvdb.MaxChunkSize`, the default by `migratekvdb.DefaultChunkSize`).
- Refreshed the help block in `docs/data-migration.md` so the rendered `(default: ...)` for `data-dir`/`tower-dir` (already auto-populated by go-flags from the programmatic `defaultDataDir`) and the new `--dest.backend` / `--chunk-size` defaults are reflected in the docs.

## Testing

- `make build` clean.
- `go test -tags="kvdb_etcd kvdb_postgres kvdb_sqlite" ./...` clean (the `cmd_migrate_db_postgres_test.go` suite explicitly sets `Backend: lncfg.PostgresBackend`, so the default flip does not affect coverage).
- `golangci-lint run --build-tags="kvdb_etcd kvdb_postgres kvdb_sqlite" --timeout 10m ./...` clean.
- Inspected `lndinit-debug migrate-db -h` output to confirm `(default: sqlite)`, the chunk-size description, and the auto-populated data-dir / tower-dir defaults are all present.

## Related

Closes #75
