### PR TITLE
migrate-db: skip missing source DBs by default

### DIFF
--- a/cmd_migrate_db.go
+++ b/cmd_migrate_db.go
@@ -99,6 +99,7 @@ type migrateDBCommand struct {
 	ForceNewMigration bool      `long:"force-new-migration" description:"Force a new migration from the beginning of the source DB so the resume state will be discarded"`
 	ForceVerifyDB     bool      `long:"force-verify-db" description:"Force a verification verifies two already marked (tombstoned and already migrated) dbs to make sure that the source db equals the content of the destination db"`
 	ChunkSize         uint64    `long:"chunk-size" description:"Chunk size for the migration in bytes"`
+	ErrorIfNoBboltDB  bool      `long:"error-if-no-bbolt-db-exists" description:"Return an error when a mandatory source bbolt DB is not found. By default missing source DBs are logged and skipped so a fresh node (no bbolt DBs yet) is treated as a successful no-op."`
 }
 
 func newMigrateDBCommand() *migrateDBCommand {
@@ -232,11 +233,24 @@ func (x *migrateDBCommand) Execute(_ []string) error {
 		// Open and check the database version.
 		srcDb, err := openSourceDb(x.Source, prefix, x.Network, true)
 		if err == kvdb.ErrDbDoesNotExist {
-			// Only skip if it's an optional because it's not
-			// required to run a wtclient or wtserver for example.
-			if optionalDBs[prefix] {
+			switch {
+			// Optional DBs (e.g. wtclient, wtserver, neutrino) are
+			// always safe to skip when missing.
+			case optionalDBs[prefix]:
 				logger.Warnf("Skipping checking db version "+
 					"of optional DB %s: not found", prefix)
+
+				continue
+
+			// A mandatory bbolt DB is missing. Treat this as a
+			// fresh node by default (LND will create the SQL DB
+			// itself on first start). Only fail if the user
+			// explicitly opted in via --error-if-no-bbolt-db-exists.
+			case !x.ErrorIfNoBboltDB:
+				logger.Warnf("Skipping checking db version "+
+					"of mandatory DB %s: not found "+
+					"(pass --error-if-no-bbolt-db-exists "+
+					"to fail instead)", prefix)
 
 				continue
 			}
@@ -281,11 +295,22 @@ func (x *migrateDBCommand) Execute(_ []string) error {
 			x.Source, prefix, x.Network, true,
 		)
 		if err == kvdb.ErrDbDoesNotExist {
-			// Only skip if it's an optional because it's not
-			// required to run a wtclient or wtserver for example.
-			if optionalDBs[prefix] {
+			switch {
+			// Optional DBs (e.g. wtclient, wtserver, neutrino) are
+			// always safe to skip when missing.
+			case optionalDBs[prefix]:
 				logger.Warnf("Skipping optional DB %s: not "+
 					"found", prefix)
+				continue
+
+			// A mandatory bbolt DB is missing. Treat this as a
+			// fresh node by default (LND will create the SQL DB
+			// itself on first start). Only fail if the user
+			// explicitly opted in via --error-if-no-bbolt-db-exists.
+			case !x.ErrorIfNoBboltDB:
+				logger.Warnf("Skipping mandatory DB %s: not "+
+					"found (pass --error-if-no-bbolt-db-"+
+					"exists to fail instead)", prefix)
 				continue
 			}
 		}

--- a/cmd_migrate_db_test.go
+++ b/cmd_migrate_db_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"testing"
 
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/kvdb/sqlite"
+	"github.com/lightningnetwork/lnd/lncfg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,4 +22,55 @@ func setupTestData(t *testing.T) string {
 	require.NoError(t, err, "failed to copy test data")
 
 	return tempDir
+}
+
+// TestMigrateDBNoBboltDBExists verifies that running migrate-db against a data
+// directory that contains no bbolt source DBs is a successful no-op by default
+// and only fails when --error-if-no-bbolt-db-exists is set.
+func TestMigrateDBNoBboltDBExists(t *testing.T) {
+	t.Parallel()
+
+	makeCmd := func(dataDir string, errIfMissing bool) *migrateDBCommand {
+		return &migrateDBCommand{
+			Source: &SourceDB{
+				Backend: lncfg.BoltBackend,
+				Bolt: &Bolt{
+					DBTimeout: kvdb.DefaultDBTimeout,
+					DataDir:   dataDir,
+					TowerDir:  dataDir,
+				},
+			},
+			Dest: &DestDB{
+				Backend: lncfg.SqliteBackend,
+				Sqlite: &Sqlite{
+					DataDir:  dataDir,
+					TowerDir: dataDir,
+					Config:   &sqlite.Config{},
+				},
+			},
+			Network:          "regtest",
+			ChunkSize:        1024,
+			ErrorIfNoBboltDB: errIfMissing,
+		}
+	}
+
+	t.Run("default skips missing DBs", func(t *testing.T) {
+		t.Parallel()
+
+		// An empty temp dir contains no bbolt DBs at all. With the
+		// default flag value the migration should succeed without
+		// touching the destination.
+		err := makeCmd(t.TempDir(), false).Execute(nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("flag forces error when missing", func(t *testing.T) {
+		t.Parallel()
+
+		err := makeCmd(t.TempDir(), true).Execute(nil)
+		require.Error(t, err)
+		require.Contains(
+			t, err.Error(), "failed to open source db",
+		)
+	})
 }

--- a/docs/data-migration.md
+++ b/docs/data-migration.md
@@ -238,6 +238,8 @@ Help Options:
           --force-verify-db                           Force a verification verifies two already marked (tombstoned and already migrated) dbs to make sure that the source db equals the
                                                       content of the destination db
           --chunk-size=                               Chunk size for the migration in bytes
+          --error-if-no-bbolt-db-exists               Return an error when a mandatory source bbolt DB is not found. By default missing source DBs are logged and skipped so a fresh node (no bbolt
+                                                      DBs yet) is treated as a successful no-op.
 
     source:
           --source.backend=[bolt]                     The source database backend. (default: bolt)


### PR DESCRIPTION
## Summary
`lndinit migrate-db` currently aborts on the first mandatory prefix with `database does not exist` when run against a fresh node (no bbolt files yet). For container/k8s init wrappers that always run `migrate-db`, this means the wrapper has to special-case "no DBs yet" or LND never gets a chance to create the SQLite DB itself.

This PR treats `ErrDbDoesNotExist` on a mandatory prefix the same way it already treats it on an optional one (log + continue), and gates the previous strict behavior behind a new opt-in flag:

```
--error-if-no-bbolt-db-exists
```

Off by default so a fresh-node migration is a successful no-op; on for operators who want a hard failure if their bbolt files vanished unexpectedly.

The second flag suggested in the issue (`--tombstone-empty-db-if-no-bbolt-db-exists`) is intentionally not part of this PR — its use case is unclear and it can be added cleanly on top later if someone wants it.

## Testing
- New `TestMigrateDBNoBboltDBExists` covers both default-skip and flag-forces-error paths against an empty data dir.
- `go test -tags="kvdb_etcd kvdb_postgres kvdb_sqlite" ./...` clean.
- `golangci-lint run --timeout 10m --build-tags="kvdb_etcd kvdb_postgres kvdb_sqlite" ./...` clean (v1.64.8 from `tools/go.mod`).
- Manual `lndinit migrate-db -h` confirms the new flag renders.

## Related
Fixes #77
