### PR TITLE
build: also publish a litd-based lndinit docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,19 +36,27 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/docker/}" >> $GITHUB_ENV
 
       # We will push tags with the format docker/v0.x.y-beta-lnd-v0.aa.bb-beta
-      # where x and y are lndinit's version and aa and bb are lnd's version.
-      # This variable LND_VERSION extracts everything after v0.x.y-lnd- so we
-      # know which base image we need to build on top of.
-      - name: Set env for LND_VERSION
-        run: echo "LND_VERSION=${RELEASE_VERSION##v*\.*\.*-beta-lnd-}" >> $GITHUB_ENV
-      
-      - name: Set env for LNDINIT_VERSION
-        run: echo "LNDINIT_VERSION=${RELEASE_VERSION%%-lnd-v*\.*\.*-beta*}" >> $GITHUB_ENV
+      # to build on top of lnd, or docker/v0.x.y-beta-litd-v0.aa.bb-alpha to
+      # build on top of litd. Everything after the -lnd-/-litd- separator is the
+      # base image version we build on top of; everything before it is lndinit's
+      # version. The separator also selects the base image.
+      - name: Set env for BASE_IMAGE, BASE_IMAGE_VERSION and LNDINIT_VERSION
+        run: |
+          if [[ "${RELEASE_VERSION}" == *-litd-* ]]; then
+            echo "BASE_IMAGE=lightninglabs/lightning-terminal" >> $GITHUB_ENV
+            echo "BASE_IMAGE_VERSION=${RELEASE_VERSION#*-litd-}" >> $GITHUB_ENV
+            echo "LNDINIT_VERSION=${RELEASE_VERSION%%-litd-*}" >> $GITHUB_ENV
+          else
+            echo "BASE_IMAGE=lightninglabs/lnd" >> $GITHUB_ENV
+            echo "BASE_IMAGE_VERSION=${RELEASE_VERSION##v*\.*\.*-beta-lnd-}" >> $GITHUB_ENV
+            echo "LNDINIT_VERSION=${RELEASE_VERSION%%-lnd-v*\.*\.*-beta*}" >> $GITHUB_ENV
+          fi
 
       - name: Set daily tag
         if: github.event.schedule == '0 1 * * *'
         run: |
-          echo "LND_VERSION=daily-testing-only" >> $GITHUB_ENV
+          echo "BASE_IMAGE=lightninglabs/lnd" >> $GITHUB_ENV
+          echo "BASE_IMAGE_VERSION=daily-testing-only" >> $GITHUB_ENV
           echo "LNDINIT_VERSION=main" >> $GITHUB_ENV
           echo "RELEASE_VERSION=daily-testing-$(date -u +%Y%m%d),${DOCKER_REPO}/${DOCKER_IMAGE}:daily-testing-only" >> $GITHUB_ENV
 
@@ -61,7 +69,8 @@ jobs:
           tags: "${{ env.DOCKER_REPO }}/${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}"
           build-args: |
             checkout=${{ env.LNDINIT_VERSION }}
-            BASE_IMAGE_VERSION=${{ env.LND_VERSION }}
+            BASE_IMAGE=${{ env.BASE_IMAGE }}
+            BASE_IMAGE_VERSION=${{ env.BASE_IMAGE_VERSION }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -440,20 +440,24 @@ Then proceed to the container image release process.
 
 ### Container image release
 
-When a new version of `lnd` is released, a new `lndinit` container image build
-is triggered by pushing a tag with the format:
-`docker/<lndinit_version>-lnd-<lnd_version>`
+When a new version of `lnd` or `litd` is released, a new `lndinit` container
+image build is triggered by pushing a tag with the format
+`docker/<lndinit_version>-lnd-<lnd_version>` (built on top of `lnd`) or
+`docker/<lndinit_version>-litd-<litd_version>` (built on top of `litd`).
 
-For example, to build an image based on lnd `v0.16.4-beta`, which includes
-lndinit `v0.1.15-beta`:
+For example, to build images based on lnd `v0.16.4-beta` and litd
+`v0.10.0-alpha`, which include lndinit `v0.1.15-beta`:
 
 ```
 LNDINIT_VERSION=v0.1.15-beta
 LND_VERSION=v0.16.4-beta
+LITD_VERSION=v0.10.0-alpha
 
 git checkout $LNDINIT_VERSION
 git tag docker/${LNDINIT_VERSION}-lnd-${LND_VERSION}
 git push docker/${LNDINIT_VERSION}-lnd-${LND_VERSION}
+git tag docker/${LNDINIT_VERSION}-litd-${LITD_VERSION}
+git push docker/${LNDINIT_VERSION}-litd-${LITD_VERSION}
 ```
 
 If lnd `v0.16.5-beta` is released and does not require additional `lndinit`


### PR DESCRIPTION
The docker release workflow now recognizes a docker/<lndinit>-litd-<litd> release tag in addition to the existing docker/<lndinit>-lnd-<lnd> format, building the lndinit binary on top of lightninglabs/lightning-terminal instead of lightninglabs/lnd. 

Push both tags to publish both images.

The nightly daily-testing-only build stays lnd-only, since litd does not publish a daily-testing-only base image.