### PR TITLE
build: deprecate windows 32-bit ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ linux-armv7 \
 linux-arm64 \
 windows-386 \
 windows-amd64 \
-windows-arm
+windows-arm64
 
 # By default we will build all systems. But with the 'sys' tag, a specific
 # system can be specified. This is useful to release for a subset of


### PR DESCRIPTION
Aligns our build process with the Go support matrix around `GOOS` and `GOARCH`.