### PR TITLE
ci: switch to self-hosted runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - name: Set up QEMU
         uses: lightninglabs/gh-actions/setup-qemu-action@39555064b3ae5c6d5c71a8ab304355faeaf3f4d4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
   ########################
   lint:
     name: lint code
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -40,15 +40,15 @@ jobs:
   ########################
   unit-test:
     name: run unit tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - name: setup go ${{ inputs.go-version }}
+      - name: setup go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5
         with:
-          go-version: '${{ inputs.go-version }}'
+          go-version: '${{ env.GO_VERSION }}'
           cache: 'true'
 
       - name: run unit test


### PR DESCRIPTION
Runs the GitHub actions workflows on self-hosted runners rather than GitHub hosted runners.