### PR TITLE
migration: batched postgres inserts and validation

### DIFF
--- a/cmd_migrate_db.go
+++ b/cmd_migrate_db.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"net/http"
@@ -99,6 +100,7 @@ type migrateDBCommand struct {
 	ForceNewMigration bool      `long:"force-new-migration" description:"Force a new migration from the beginning of the source DB so the resume state will be discarded"`
 	ForceVerifyDB     bool      `long:"force-verify-db" description:"Force a verification verifies two already marked (tombstoned and already migrated) dbs to make sure that the source db equals the content of the destination db"`
 	ChunkSize         uint64    `long:"chunk-size" description:"Chunk size for the migration in bytes"`
+	BulkWrites        bool      `long:"bulk-writes" description:"Enable the fast postgres path for a fresh migration: batched multi-row INSERTs for the migration and batched child-fetch verification. Both drastically reduce round-trips (much faster over a network) but are only supported for a postgres destination and cannot resume an interrupted migration."`
 }
 
 func newMigrateDBCommand() *migrateDBCommand {
@@ -477,16 +479,38 @@ func (x *migrateDBCommand) Execute(_ []string) error {
 			return err
 		}
 
-		err = migrator.Migrate(ctx, srcDb, destDb)
+		// The batched bulk write path is only supported for a postgres
+		// destination. For any other backend we fall back to the standard
+		// (resumable) migration path.
+		useBulk := x.BulkWrites &&
+			x.Dest.Backend == lncfg.PostgresBackend
+		if x.BulkWrites && !useBulk {
+			logger.Warnf("Ignoring --bulk-writes for prefix `%s`: "+
+				"batched writes are only supported for a postgres "+
+				"destination; using the standard migration path",
+				prefix)
+		}
+
+		if useBulk {
+			err = x.migrateBulk(ctx, migrator, srcDb, prefix)
+		} else {
+			err = migrator.Migrate(ctx, srcDb, destDb)
+		}
 		if err != nil {
 			return err
 		}
 		logger.Infof("Migration of db with prefix %s completed", prefix)
 
 		// We migrated the DB successfully, now we verify the migration.
-		err = migrator.VerifyMigration(
-			ctx, srcDb, destDb, false,
-		)
+		// On the postgres fast path we use batched verification, which
+		// reads the target with far fewer round-trips (one query per batch
+		// of buckets instead of per bucket); otherwise we use the standard
+		// hierarchical verification.
+		if useBulk {
+			err = x.verifyBatched(ctx, migrator, srcDb, prefix)
+		} else {
+			err = migrator.VerifyMigration(ctx, srcDb, destDb, false)
+		}
 		if err != nil {
 			return err
 		}
@@ -587,6 +611,69 @@ func (x *migrateDBCommand) validateDBBackends() error {
 		return fmt.Errorf("destination database must be sqlite or "+
 			"postgres, got: %s", x.Dest.Backend)
 	}
+}
+
+// migrateBulk runs a fresh migration into a postgres destination using the
+// batched multi-row INSERT path. It opens a direct database/sql connection
+// because the batched writes cannot be expressed through the kvdb abstraction.
+//
+// The pgx driver is registered by the postgres kvdb backend, which is only
+// compiled with the kvdb_postgres build tag. Reaching this code implies the
+// destination backend is postgres, which in turn implies the binary was built
+// with that tag and the driver is available.
+func (x *migrateDBCommand) migrateBulk(ctx context.Context,
+	migrator *migratekvdb.Migrator, srcDb kvdb.Backend, prefix string) error {
+
+	rawDB, err := sql.Open("pgx", x.Dest.Postgres.Dsn)
+	if err != nil {
+		return fmt.Errorf("failed to open raw postgres connection for "+
+			"bulk migration: %w", err)
+	}
+
+	// The bulk path uses a single transaction, so a tiny pool is enough.
+	rawDB.SetMaxOpenConns(2)
+
+	// The kvdb postgres backend stores each namespace in a table named
+	// `<prefix>_kv` in the default (public) schema.
+	table := prefix + "_kv"
+
+	logger.Infof("Using batched bulk write path for prefix `%s` "+
+		"(table `%s`)", prefix, table)
+
+	migErr := migrator.MigrateBulkSQL(ctx, srcDb, rawDB, table, 0)
+	if closeErr := rawDB.Close(); closeErr != nil {
+		logger.Errorf("Error closing raw postgres connection: %v",
+			closeErr)
+	}
+
+	return migErr
+}
+
+// verifyBatched verifies a postgres destination using batched child fetches,
+// which issue one query per batch of buckets rather than one per bucket. Like
+// migrateBulk it needs a direct database/sql connection because the batching
+// works on the target's internal row ids, which kvdb does not expose.
+func (x *migrateDBCommand) verifyBatched(ctx context.Context,
+	migrator *migratekvdb.Migrator, srcDb kvdb.Backend, prefix string) error {
+
+	rawDB, err := sql.Open("pgx", x.Dest.Postgres.Dsn)
+	if err != nil {
+		return fmt.Errorf("failed to open raw postgres connection for "+
+			"batched verification: %w", err)
+	}
+	rawDB.SetMaxOpenConns(2)
+
+	table := prefix + "_kv"
+	logger.Infof("Using batched verification for prefix `%s` (table `%s`)",
+		prefix, table)
+
+	verifyErr := migrator.VerifyBatchedSQL(ctx, srcDb, rawDB, table, 0)
+	if closeErr := rawDB.Close(); closeErr != nil {
+		logger.Errorf("Error closing raw postgres connection: %v",
+			closeErr)
+	}
+
+	return verifyErr
 }
 
 // openSourceDb opens the source database and also checks if there is enough

--- a/cmd_migrate_db_postgres_test.go
+++ b/cmd_migrate_db_postgres_test.go
@@ -117,7 +117,8 @@ func (p *PostgresTestSetup) getDBConfigs() (*SourceDB, *DestDB) {
 // TestMigrateDBPostgres tests the migration of a database from Bolt to
 // Postgres.
 func TestMigrateDBPostgres(t *testing.T) {
-	t.Parallel()
+	// NOTE: not parallel. setupEmbeddedPostgres binds a fixed port (9877),
+	// shared with the other postgres tests, so these must run sequentially.
 
 	// Setup postgres.
 	setup := setupEmbeddedPostgres(t)
@@ -141,4 +142,35 @@ func TestMigrateDBPostgres(t *testing.T) {
 
 	err := cmd.Execute(nil)
 	require.NoError(t, err, "failed to execute migration")
+}
+
+// TestMigrateDBPostgresBulk runs the full migrate-db command end-to-end with the
+// batched bulk write path enabled, exercising the CLI wiring (raw pgx
+// connection, per-namespace table naming, markers and verification) across all
+// of the migrated databases.
+func TestMigrateDBPostgresBulk(t *testing.T) {
+	// NOTE: not parallel. The embedded postgres fixture binds a fixed port
+	// (shared with TestMigrateDBPostgres), so these must not run
+	// concurrently.
+
+	setup := setupEmbeddedPostgres(t)
+	defer func() {
+		require.NoError(t, setup.cleanup())
+	}()
+
+	setup.setupTestDir(t)
+	setup.createTestDatabase(t)
+
+	sourceDB, destDB := setup.getDBConfigs()
+
+	cmd := &migrateDBCommand{
+		Source:     sourceDB,
+		Dest:       destDB,
+		Network:    "regtest",
+		ChunkSize:  1024,
+		BulkWrites: true,
+	}
+
+	err := cmd.Execute(nil)
+	require.NoError(t, err, "failed to execute bulk migration")
 }

--- a/migrate_edgecases_test.go
+++ b/migrate_edgecases_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+// discardWriter is an io.Writer that drops everything, to silence test logs.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// edgeCaseCounts holds the exact leaf-key and bucket counts written by
+// buildEdgeCaseBoltSource, so tests can assert the migrator counted the same.
+type edgeCaseCounts struct {
+	leaves  int
+	buckets int
+}
+
+// buildEdgeCaseBoltSource creates a bolt DB at path that deliberately exercises
+// the tricky shapes the migration + verification must handle:
+//   - empty ([]byte{}) leaf values (the SQLite nil-vs-empty regression)
+//   - non-printable/binary keys and values
+//   - keys where one is a prefix of another (cursor ordering / seek edges)
+//   - a bucket with an explicit sequence number
+//   - an empty bucket (no entries)
+//   - multi-level nested buckets with leaves and sub-buckets interleaved by key
+//
+// It returns the exact counts written.
+func buildEdgeCaseBoltSource(t *testing.T, path string) edgeCaseCounts {
+	t.Helper()
+
+	db, err := bbolt.Open(path, 0600, &bbolt.Options{
+		Timeout: time.Minute,
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+
+	var c edgeCaseCounts
+
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		// 1) Flat bucket with an empty value, binary key/value, and
+		//    prefix-overlapping keys.
+		flat, err := tx.CreateBucket([]byte("flat"))
+		require.NoError(t, err)
+		c.buckets++
+
+		put := func(b *bbolt.Bucket, k, v []byte) {
+			require.NoError(t, b.Put(k, v))
+			c.leaves++
+		}
+		put(flat, []byte("alpha"), []byte("value-alpha"))
+		put(flat, []byte("empty"), []byte{})              // empty value
+		put(flat, []byte("k"), []byte("v"))               // prefix of "k1"
+		put(flat, []byte("k1"), []byte("v1"))             // prefix of "k10"
+		put(flat, []byte("k10"), []byte("v10"))           // ordering edge
+		put(flat, []byte{0x00, 0xff, 0x10}, []byte{0x00}) // binary key/value
+		put(flat, []byte("zeros"), []byte{0, 0, 0, 0})    // non-empty zero bytes
+
+		// 2) Bucket with an explicit sequence number set.
+		seqB, err := tx.CreateBucket([]byte("with-seq"))
+		require.NoError(t, err)
+		c.buckets++
+		require.NoError(t, seqB.SetSequence(4242))
+		put(seqB, []byte("one"), []byte("1"))
+		put(seqB, []byte("two"), []byte("2"))
+
+		// 3) An empty bucket (no entries).
+		_, err = tx.CreateBucket([]byte("empty-bucket"))
+		require.NoError(t, err)
+		c.buckets++
+
+		// 4) Nested buckets: leaves and sub-buckets interleaved by key
+		//    order, three levels deep, one nested bucket carrying a
+		//    sequence, and a nested empty value.
+		nested, err := tx.CreateBucket([]byte("nested"))
+		require.NoError(t, err)
+		c.buckets++
+		// Keys chosen so leaves and sub-buckets interleave when sorted:
+		// "a-leaf" < "m-sub" < "z-leaf".
+		put(nested, []byte("a-leaf"), []byte("first"))
+		put(nested, []byte("z-leaf"), []byte{}) // empty value in nested
+
+		sub, err := nested.CreateBucket([]byte("m-sub"))
+		require.NoError(t, err)
+		c.buckets++
+		require.NoError(t, sub.SetSequence(7))
+		put(sub, []byte("s1"), []byte("sv1"))
+		put(sub, []byte("s2"), []byte("sv2"))
+
+		subsub, err := sub.CreateBucket([]byte("deep"))
+		require.NoError(t, err)
+		c.buckets++
+		put(subsub, []byte("d1"), []byte("deepval"))
+
+		return nil
+	}))
+
+	return c
+}
+
+// compareBackends independently walks the source and target key/value stores and
+// asserts they are byte-for-byte identical (nil and empty values treated as
+// equal, matching bolt/SQL round-trip semantics). This is an independent check,
+// separate from the migrator's own VerifyMigration.
+func compareBackends(t *testing.T, src, target kvdb.Backend) {
+	t.Helper()
+
+	var walk func(sb, tb kvdb.RBucket, path string)
+	walk = func(sb, tb kvdb.RBucket, path string) {
+		require.NoError(t, sb.ForEach(func(k, v []byte) error {
+			if v == nil {
+				// Nested bucket on the source side.
+				sn := sb.NestedReadBucket(k)
+				tn := tb.NestedReadBucket(k)
+				require.NotNil(t, tn, "missing nested bucket %s/%x",
+					path, k)
+				require.Equal(t, sn.Sequence(), tn.Sequence(),
+					"sequence mismatch at %s/%x", path, k)
+				walk(sn, tn, path+"/"+string(k))
+				return nil
+			}
+
+			tv := tb.Get(k)
+			require.True(t, bytes.Equal(v, tv),
+				"value mismatch at %s/%x: src=%x target=%x",
+				path, k, v, tv)
+			return nil
+		}))
+	}
+
+	require.NoError(t, src.View(func(stx kvdb.RTx) error {
+		return target.View(func(ttx kvdb.RTx) error {
+			return stx.ForEachBucket(func(name []byte) error {
+				sb := stx.ReadBucket(name)
+				tb := ttx.ReadBucket(name)
+				require.NotNil(t, tb, "missing root bucket %x", name)
+				require.Equal(t, sb.Sequence(), tb.Sequence(),
+					"root sequence mismatch %x", name)
+				walk(sb, tb, string(name))
+				return nil
+			})
+		}, func() {})
+	}, func() {}))
+}

--- a/migrate_postgres_edgecases_test.go
+++ b/migrate_postgres_edgecases_test.go
@@ -1,0 +1,214 @@
+//go:build kvdb_postgres
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/lndinit/migratekvdb"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/kvdb/postgres"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+const pgEdgeTable = "channeldb_kv"
+
+// pgEdgeEnv bundles a fresh postgres target for one (sub)test.
+type pgEdgeEnv struct {
+	src    kvdb.Backend
+	target kvdb.Backend
+	raw    *sql.DB
+	meta   *bbolt.DB
+}
+
+// newPGEdgeEnv builds an edge-case bolt source and a fresh postgres target DB.
+func newPGEdgeEnv(t *testing.T, setup *PostgresTestSetup) (*pgEdgeEnv, edgeCaseCounts) {
+	t.Helper()
+	setup.createTestDatabase(t)
+	dsn := setup.getDsn(setup.dbName)
+
+	tempDir := t.TempDir()
+	srcPath := filepath.Join(tempDir, "source.db")
+	counts := buildEdgeCaseBoltSource(t, srcPath)
+
+	src, err := kvdb.Open(
+		kvdb.BoltBackendName, srcPath, true, time.Minute, true,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	target, err := kvdb.Open(
+		kvdb.PostgresBackendName, context.Background(),
+		&postgres.Config{
+			Dsn: dsn, Timeout: time.Minute, MaxConnections: 10,
+		},
+		"channeldb",
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = target.Close() })
+
+	raw, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = raw.Close() })
+
+	meta, err := bbolt.Open(filepath.Join(tempDir, "meta.db"), 0600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = meta.Close() })
+
+	return &pgEdgeEnv{src: src, target: target, raw: raw, meta: meta}, counts
+}
+
+func newTestMigrator(t *testing.T, meta *bbolt.DB) *migratekvdb.Migrator {
+	t.Helper()
+	m, err := migratekvdb.New(migratekvdb.Config{
+		Logger:       btclog.NewSLogger(btclog.NewDefaultHandler(discardWriter{})),
+		MetaDB:       meta,
+		DBPrefixName: "channeldb",
+	})
+	require.NoError(t, err)
+	return m
+}
+
+// TestBulkMigratePostgres covers the batched bulk write path end-to-end on edge
+// cases, plus guards, batch clamping, negative verification, and crash recovery.
+func TestBulkMigratePostgres(t *testing.T) {
+	setup := setupEmbeddedPostgres(t)
+	defer func() { require.NoError(t, setup.cleanup()) }()
+
+	ctx := context.Background()
+
+	// --- happy path: bulk migrate + ForAll verify + independent compare ---
+	t.Run("happy_path", func(t *testing.T) {
+		env, _ := newPGEdgeEnv(t, setup)
+		m := newTestMigrator(t, env.meta)
+
+		require.NoError(t, m.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0))
+		require.NoError(t, m.VerifyMigration(ctx, env.src, env.target, false))
+		compareBackends(t, env.src, env.target)
+	})
+
+	// --- batched verify: correctness, with a tiny batch size to exercise
+	//     batch boundaries and multiple BFS levels ---
+	t.Run("batched_verify", func(t *testing.T) {
+		env, _ := newPGEdgeEnv(t, setup)
+		m := newTestMigrator(t, env.meta)
+
+		require.NoError(t, m.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0))
+		require.NoError(t, m.VerifyBatchedSQL(ctx, env.src, env.raw, pgEdgeTable, 2))
+		compareBackends(t, env.src, env.target)
+	})
+
+	// --- batched verify must also detect target corruption ---
+	t.Run("batched_verify_catches_mutation", func(t *testing.T) {
+		env, _ := newPGEdgeEnv(t, setup)
+		m := newTestMigrator(t, env.meta)
+		require.NoError(t, m.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0))
+
+		_, err := env.raw.ExecContext(ctx, "UPDATE "+pgEdgeTable+
+			" SET value = '\\xdeadbeef' WHERE id = (SELECT id FROM "+
+			pgEdgeTable+" WHERE value IS NOT NULL ORDER BY id LIMIT 1)")
+		require.NoError(t, err)
+
+		require.Error(t, m.VerifyBatchedSQL(ctx, env.src, env.raw, pgEdgeTable, 2),
+			"batched verify should detect a mutated value")
+	})
+
+	// --- batched verify must detect an extra top-level bucket in the target
+	//     (a check the sqlite-combining compareDBs path deliberately omits) ---
+	t.Run("batched_verify_catches_extra_root", func(t *testing.T) {
+		env, _ := newPGEdgeEnv(t, setup)
+		m := newTestMigrator(t, env.meta)
+		require.NoError(t, m.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0))
+
+		_, err := env.raw.ExecContext(ctx, "INSERT INTO "+pgEdgeTable+
+			" (parent_id, key) VALUES (NULL, '\\xfefefefe')")
+		require.NoError(t, err)
+
+		require.Error(t, m.VerifyBatchedSQL(ctx, env.src, env.raw, pgEdgeTable, 2),
+			"batched verify should detect an extra top-level bucket")
+	})
+
+	// --- batch size larger than the param limit must clamp, not fail ---
+	t.Run("batch_clamp", func(t *testing.T) {
+		env, _ := newPGEdgeEnv(t, setup)
+		m := newTestMigrator(t, env.meta)
+
+		// 100000 rows * 3 params would blow past 65535; must be clamped.
+		require.NoError(t, m.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 100000))
+		require.NoError(t, m.VerifyMigration(ctx, env.src, env.target, false))
+	})
+
+	// --- refuse to bulk-migrate into a non-empty target ---
+	t.Run("refuse_non_empty", func(t *testing.T) {
+		env, _ := newPGEdgeEnv(t, setup)
+		m1 := newTestMigrator(t, env.meta)
+		require.NoError(t, m1.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0))
+
+		// A brand-new migrator (fresh meta) pointed at the now-populated
+		// target must refuse rather than double-write.
+		meta2, err := bbolt.Open(filepath.Join(t.TempDir(), "m2.db"), 0600, nil)
+		require.NoError(t, err)
+		defer meta2.Close()
+		m2 := newTestMigrator(t, meta2)
+
+		err = m2.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not empty")
+	})
+
+	// --- crash recovery: an interrupted attempt leaves the in-progress
+	//     marker; a re-run must truncate and complete successfully ---
+	t.Run("recovery_after_interrupt", func(t *testing.T) {
+		env, _ := newPGEdgeEnv(t, setup)
+
+		// First attempt: cancel the context so it fails AFTER writing the
+		// in-progress marker but before/at the data transaction.
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		m1 := newTestMigrator(t, env.meta)
+		err := m1.MigrateBulkSQL(cancelledCtx, env.src, env.raw, pgEdgeTable, 0)
+		require.Error(t, err, "cancelled attempt should fail")
+
+		// Second attempt with a fresh migrator on the SAME meta DB: it
+		// should detect the marker, truncate, and complete.
+		m2 := newTestMigrator(t, env.meta)
+		require.NoError(t, m2.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0))
+		require.NoError(t, m2.VerifyMigration(ctx, env.src, env.target, false))
+		compareBackends(t, env.src, env.target)
+	})
+
+	// --- verification must CATCH target corruption (proves it isn't a no-op) ---
+	corruptCases := map[string]string{
+		"missing_row": "DELETE FROM " + pgEdgeTable +
+			" WHERE id = (SELECT id FROM " + pgEdgeTable +
+			" WHERE value IS NOT NULL ORDER BY id LIMIT 1)",
+		"mutated_value": "UPDATE " + pgEdgeTable +
+			" SET value = '\\xdeadbeef' WHERE id = (SELECT id FROM " +
+			pgEdgeTable + " WHERE value IS NOT NULL ORDER BY id LIMIT 1)",
+		"extra_row": "INSERT INTO " + pgEdgeTable +
+			" (parent_id, key, value) SELECT parent_id, '\\xffffffff', " +
+			"'\\x00' FROM " + pgEdgeTable +
+			" WHERE value IS NOT NULL ORDER BY id LIMIT 1",
+	}
+	for name, stmt := range corruptCases {
+		t.Run("verify_catches_"+name, func(t *testing.T) {
+			env, _ := newPGEdgeEnv(t, setup)
+			m := newTestMigrator(t, env.meta)
+			require.NoError(t, m.MigrateBulkSQL(ctx, env.src, env.raw, pgEdgeTable, 0))
+
+			_, err := env.raw.ExecContext(ctx, stmt)
+			require.NoError(t, err, "corruption statement failed")
+
+			// Verification is fresh (bulk only wrote migration state),
+			// so this exercises the full compare and must fail.
+			require.Error(t, m.VerifyMigration(ctx, env.src, env.target, false),
+				"verification should detect %s", name)
+		})
+	}
+}

--- a/migrate_sqlite_edgecases_test.go
+++ b/migrate_sqlite_edgecases_test.go
@@ -1,0 +1,76 @@
+//go:build kvdb_sqlite
+
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btclog/v2"
+	"github.com/lightninglabs/lndinit/migratekvdb"
+	"github.com/lightningnetwork/lnd/kvdb"
+	"github.com/lightningnetwork/lnd/kvdb/sqlite"
+	"github.com/lightningnetwork/lnd/kvdb/sqlbase"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+// openSqliteTarget opens a fresh sqlite kvdb backend in dir for the given prefix.
+func openSqliteTarget(t *testing.T, dir, prefix string) kvdb.Backend {
+	t.Helper()
+	sqlbase.Init(0)
+
+	target, err := kvdb.Open(
+		kvdb.SqliteBackendName, context.Background(),
+		&sqlite.Config{Timeout: time.Minute}, dir, "test.sqlite", prefix,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = target.Close() })
+
+	return target
+}
+
+// TestMigrateEdgeCasesSqlite migrates an edge-case bolt DB into sqlite via the
+// normal (per-key) migrate path and verifies with the streaming ForAll path.
+// This is the regression test for the SQLite empty-value bug: sqlite decodes an
+// empty stored value as nil, and the ForAll verify must not mistake that for a
+// bucket/type mismatch.
+func TestMigrateEdgeCasesSqlite(t *testing.T) {
+	tempDir := t.TempDir()
+	srcPath := filepath.Join(tempDir, "source.db")
+
+	counts := buildEdgeCaseBoltSource(t, srcPath)
+	require.Greater(t, counts.leaves, 0)
+
+	src, err := kvdb.Open(
+		kvdb.BoltBackendName, srcPath, true, time.Minute, true,
+	)
+	require.NoError(t, err)
+	defer src.Close()
+
+	target := openSqliteTarget(t, tempDir, "channeldb")
+
+	metaDB, err := bbolt.Open(filepath.Join(tempDir, "meta.db"), 0600, nil)
+	require.NoError(t, err)
+	defer metaDB.Close()
+
+	logger := btclog.NewSLogger(btclog.NewDefaultHandler(discardWriter{}))
+	migrator, err := migratekvdb.New(migratekvdb.Config{
+		Logger:       logger,
+		MetaDB:       metaDB,
+		DBPrefixName: "channeldb",
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Migrate (per-key path), then verify via ForAll.
+	require.NoError(t, migrator.Migrate(ctx, src, target))
+	require.NoError(t, migrator.VerifyMigration(ctx, src, target, false),
+		"ForAll verify must accept sqlite empty-value leaves")
+
+	// Independent byte-for-byte cross-check.
+	compareBackends(t, src, target)
+}

--- a/migratekvdb/bulk.go
+++ b/migratekvdb/bulk.go
@@ -1,0 +1,309 @@
+package migratekvdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+// DefaultBulkBatchSize is the number of leaf rows accumulated before a single
+// multi-row INSERT is issued. At 3 params/row this stays well under postgres'
+// 65535-parameter statement limit.
+const DefaultBulkBatchSize = 1000
+
+// MaxBulkBatchSize is the largest permitted batch size. Each row contributes 3
+// bind parameters (parent_id, key, value); postgres caps a statement at 65535
+// parameters, so we cap rows at 65535/3 = 21845 to guarantee we never exceed it.
+const MaxBulkBatchSize = 65535 / 3
+
+// bulkRow is a buffered leaf key/value pair destined for the given bucket.
+type bulkRow struct {
+	parentID int64
+	key      []byte
+	value    []byte
+}
+
+// bulkWriter accumulates leaf rows and flushes them as multi-row INSERTs within
+// a single SQL transaction. Bucket rows are inserted immediately (they need
+// RETURNING id, and their children reference them via the parent_id FK).
+type bulkWriter struct {
+	ctx       context.Context
+	tx        *sql.Tx
+	table     string
+	batchSize int
+	rows      []bulkRow
+}
+
+// insertBucket inserts a bucket row and returns its generated id. parentID is
+// nil for a top-level bucket (parent_id NULL). A non-zero sequence is persisted.
+//
+// The bucket row is inserted immediately (not buffered) because its generated
+// id is needed right away for its children's parent_id, and because the
+// parent_id foreign key requires the parent row to exist before any child row
+// referencing it is inserted.
+func (bw *bulkWriter) insertBucket(parentID *int64, key []byte,
+	seq uint64) (int64, error) {
+
+	kc := make([]byte, len(key))
+	copy(kc, key)
+
+	var id int64
+	if seq != 0 {
+		err := bw.tx.QueryRowContext(bw.ctx,
+			"INSERT INTO "+bw.table+" (parent_id, key, sequence) "+
+				"VALUES ($1,$2,$3) RETURNING id",
+			parentID, kc, int64(seq),
+		).Scan(&id)
+
+		return id, err
+	}
+
+	err := bw.tx.QueryRowContext(bw.ctx,
+		"INSERT INTO "+bw.table+" (parent_id, key) "+
+			"VALUES ($1,$2) RETURNING id",
+		parentID, kc,
+	).Scan(&id)
+
+	return id, err
+}
+
+// addLeaf buffers a leaf key/value pair, flushing when the batch is full. The
+// key and value are copied because the source cursor reuses its buffers.
+func (bw *bulkWriter) addLeaf(parentID int64, k, v []byte) error {
+	kc := make([]byte, len(k))
+	copy(kc, k)
+
+	// Use make+copy (never append(nil,...)) so an empty-but-non-nil value is
+	// stored as an empty BYTEA rather than NULL (NULL means "sub-bucket").
+	vc := make([]byte, len(v))
+	copy(vc, v)
+
+	bw.rows = append(bw.rows, bulkRow{parentID: parentID, key: kc, value: vc})
+	if len(bw.rows) >= bw.batchSize {
+		return bw.flush()
+	}
+
+	return nil
+}
+
+// flush writes all buffered leaf rows as a single multi-row INSERT.
+func (bw *bulkWriter) flush() error {
+	if len(bw.rows) == 0 {
+		return nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO " + bw.table + " (parent_id, key, value) VALUES ")
+	args := make([]interface{}, 0, len(bw.rows)*3)
+	for i, r := range bw.rows {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		n := i * 3
+		fmt.Fprintf(&sb, "($%d,$%d,$%d)", n+1, n+2, n+3)
+		args = append(args, r.parentID, r.key, r.value)
+	}
+
+	_, err := bw.tx.ExecContext(bw.ctx, sb.String(), args...)
+	bw.rows = bw.rows[:0]
+
+	return err
+}
+
+// MigrateBulkSQL performs a fresh bolt->SQL migration using batched multi-row
+// INSERTs instead of one INSERT per key, collapsing the per-key round-trips that
+// dominate a networked postgres migration.
+//
+// It writes directly to the target table via the provided *sql.DB (opened with
+// the same driver as the kvdb backend, e.g. "pgx"), bypassing kvdb's per-row
+// Put. The entire migration runs in a single transaction: on success the
+// migration state is marked finished; on error nothing is committed.
+//
+// NOTE: This path is fresh-only. Resume is not supported here; callers should
+// use Migrate for resuming an interrupted migration.
+func (m *Migrator) MigrateBulkSQL(ctx context.Context, sourceDB kvdb.Backend,
+	db *sql.DB, table string, batchSize int) error {
+
+	switch {
+	case batchSize <= 0:
+		batchSize = DefaultBulkBatchSize
+
+	case batchSize > MaxBulkBatchSize:
+		m.cfg.Logger.Warnf("Requested bulk batch size %d exceeds the "+
+			"maximum of %d (postgres parameter limit); clamping",
+			batchSize, MaxBulkBatchSize)
+		batchSize = MaxBulkBatchSize
+	}
+
+	m.cfg.Logger.Infof("Bulk-migrating database with prefix `%s` into `%s` "+
+		"(batch size %d)", m.cfg.DBPrefixName, table, batchSize)
+
+	// Read any existing migration state. Bulk is always a fresh migration,
+	// but we still need to detect (a) an already-finished migration and
+	// (b) a previous bulk attempt that was interrupted.
+	if err := m.migration.read(); err != nil &&
+		!errors.Is(err, errNoMetaBucket) &&
+		!errors.Is(err, errNoStateFound) {
+
+		return fmt.Errorf("failed to read migration state: %w", err)
+	}
+
+	if m.migration.persistedState.Finished {
+		m.cfg.Logger.Infof("Migration already finished")
+
+		return nil
+	}
+
+	// If a previous bulk attempt set the in-progress marker, it may have
+	// partially or even fully committed to the target before crashing (the
+	// SQL target and this bolt meta DB cannot share a transaction). We own
+	// the table in that case, so recovery is simply: truncate and redo.
+	recovering := m.migration.persistedState.BulkInProgress
+
+	// Reset to a fresh state; bulk never resumes mid-way.
+	m.migration.persistedState = newPersistedState()
+
+	if recovering {
+		m.cfg.Logger.Warnf("Detected an interrupted previous bulk "+
+			"migration; truncating target table %s and restarting",
+			table)
+
+		if _, err := db.ExecContext(
+			ctx, "TRUNCATE TABLE "+table,
+		); err != nil {
+			return fmt.Errorf("failed to truncate target table %s "+
+				"for recovery: %w", table, err)
+		}
+	} else {
+		// Fresh run: the target table must be empty.
+		var count int
+		if err := db.QueryRowContext(
+			ctx, "SELECT COUNT(*) FROM "+table,
+		).Scan(&count); err != nil {
+			return fmt.Errorf("failed to count rows in target table "+
+				"%s: %w", table, err)
+		}
+		if count > 0 {
+			return fmt.Errorf("target table %s is not empty (%d "+
+				"rows); refusing to bulk-migrate", table, count)
+		}
+	}
+
+	// Persist the in-progress marker BEFORE writing any data so that a crash
+	// after the SQL commit (but before we record completion) is recoverable
+	// via the truncate-and-retry path above.
+	m.migration.persistedState.BulkInProgress = true
+	if err := m.migration.write(); err != nil {
+		return fmt.Errorf("failed to write bulk in-progress marker: %w",
+			err)
+	}
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	bw := &bulkWriter{
+		ctx:       ctx,
+		tx:        tx,
+		table:     table,
+		batchSize: batchSize,
+	}
+
+	err = sourceDB.View(func(rtx kvdb.RTx) error {
+		return rtx.ForEachBucket(func(name []byte) error {
+			src := rtx.ReadBucket(name)
+			if src == nil {
+				return fmt.Errorf("source root bucket not found "+
+					"for key %x", name)
+			}
+
+			m.migration.persistedState.ProcessedBuckets++
+
+			return m.bulkBucket(bw, src, name, nil)
+		})
+	}, func() {})
+	if err != nil {
+		return err
+	}
+
+	if err := bw.flush(); err != nil {
+		return fmt.Errorf("failed to flush final batch: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit bulk migration: %w", err)
+	}
+
+	m.cfg.Logger.Infof("Bulk migration complete, processed %d keys, "+
+		"%d buckets", m.migration.persistedState.ProcessedKeys,
+		m.migration.persistedState.ProcessedBuckets)
+
+	// Clear the in-progress marker and record completion. The SQL data is
+	// already durably committed; if this meta write fails, the next run
+	// sees the marker still set and recovers via truncate-and-retry.
+	m.migration.setFinalState()
+	m.migration.persistedState.BulkInProgress = false
+
+	return m.migration.write()
+}
+
+// bulkBucket inserts the bucket row for src, then walks its contents: leaf
+// key/values are buffered for batched insertion; nested buckets are recursed
+// into (inserted immediately so their children's parent_id FK is satisfied).
+func (m *Migrator) bulkBucket(bw *bulkWriter, src kvdb.RBucket, key []byte,
+	parentID *int64) error {
+
+	// Emit progress once per bucket (time-gated inside the logger) so that
+	// bucket-heavy databases don't appear hung while migrating many small
+	// nested buckets.
+	m.logMigrationProgress(NewBucketPath([][]byte{key}))
+
+	id, err := bw.insertBucket(parentID, key, src.Sequence())
+	if err != nil {
+		return fmt.Errorf("failed to insert bucket row: %w", err)
+	}
+
+	cursor := src.ReadCursor()
+	for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
+		select {
+		case <-bw.ctx.Done():
+			return bw.ctx.Err()
+		default:
+		}
+
+		if v == nil {
+			// Nested bucket: must exist before its children reference
+			// it, so flush pending leaves is unnecessary (parent row
+			// already inserted). Recurse.
+			sub := src.NestedReadBucket(k)
+			if sub == nil {
+				return fmt.Errorf("source nested bucket not found "+
+					"for key %x", k)
+			}
+
+			m.migration.persistedState.ProcessedBuckets++
+
+			if err := m.bulkBucket(bw, sub, k, &id); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		if err := bw.addLeaf(id, k, v); err != nil {
+			return fmt.Errorf("failed to add leaf: %w", err)
+		}
+
+		m.migration.persistedState.ProcessedKeys++
+		m.migratedKeysSinceStart++
+		m.logMigrationProgress(NewBucketPath([][]byte{key}))
+	}
+
+	return nil
+}

--- a/migratekvdb/migration.go
+++ b/migratekvdb/migration.go
@@ -100,6 +100,14 @@ type Migrator struct {
 	// also resume the verification.
 	verification *VerificationState
 
+	// verifyForAll, when true, uses the streaming ForAll read path for
+	// verification (one query per bucket) instead of the per-key cursor
+	// (one query per key). It is only enabled for a fresh (non-resuming)
+	// verification against a backend that supports kvdb.ExtendedRBucket
+	// (postgres/sqlite); resume and bolt targets fall back to the cursor
+	// path which is fully preserved.
+	verifyForAll bool
+
 	// Rate tracking fields to track the progress of the migration and
 	// verification.
 	startTimeMigration     time.Time
@@ -466,6 +474,10 @@ func (m *Migrator) migrateBucket(ctx context.Context,
 		}
 
 	case false:
+		// Emit progress once per bucket (time-gated) so bucket-heavy
+		// databases don't appear hung while migrating many small buckets.
+		m.logMigrationProgress(path)
+
 		// Only set sequence if source bucket has a non-zero sequence
 		// otherwise we keep for the sql case the sequence is a NULL
 		// value.
@@ -673,6 +685,12 @@ func (m *Migrator) VerifyMigration(ctx context.Context,
 		return err
 	}
 
+	// Decide the verification read strategy once for the whole run. A fresh
+	// verification can use the streaming ForAll path (one query per bucket);
+	// a resuming verification uses the cursor path which supports mid-bucket
+	// seek-based resume. Freezing this here avoids mixing paths mid-run.
+	m.verifyForAll = !m.verification.resuming
+
 	err = m.compareDBs(ctx, sourceDB, targetDB)
 	if err != nil {
 		return err
@@ -790,9 +808,163 @@ func (m *Migrator) compareDBs(ctx context.Context, srcDB,
 	}, func() {})
 }
 
-// walkAndCompare walks source and target buckets in parallel,
-// comparing their contents.
+// walkAndCompare walks source and target buckets in parallel, comparing their
+// contents. It dispatches to the streaming ForAll path when enabled and
+// supported, otherwise to the per-key cursor path.
 func (m *Migrator) walkAndCompare(ctx context.Context, srcBucket,
+	targetBucket kvdb.RBucket, bucketPath BucketPath) error {
+
+	if m.verifyForAll {
+		if ext, ok := targetBucket.(kvdb.ExtendedRBucket); ok {
+			return m.walkAndCompareForAll(
+				ctx, srcBucket, ext, bucketPath,
+			)
+		}
+	}
+
+	return m.walkAndCompareCursor(ctx, srcBucket, targetBucket, bucketPath)
+}
+
+// walkAndCompareForAll verifies a bucket by streaming the target's entries with
+// a single ForAll query (instead of one query per key) and comparing them in
+// lockstep against the source cursor. Nested buckets are recursed into only
+// after the streaming read completes, honoring ForAll's constraint that no
+// additional queries may be issued from within its callback.
+//
+// NOTE: This is used for fresh (non-resuming) verifications only; see
+// walkAndCompare.
+func (m *Migrator) walkAndCompareForAll(ctx context.Context, srcBucket kvdb.RBucket,
+	targetExt kvdb.ExtendedRBucket, bucketPath BucketPath) error {
+
+	m.cfg.Logger.Debugf("Walking and comparing bucket (ForAll): %v",
+		bucketPath)
+
+	// ExtendedRBucket embeds RBucket, so it exposes Sequence/NestedReadBucket.
+	if srcBucket.Sequence() != targetExt.Sequence() {
+		return fmt.Errorf("sequence number mismatch at path %v: "+
+			"source=%d target=%d", bucketPath, srcBucket.Sequence(),
+			targetExt.Sequence())
+	}
+
+	srcCursor := srcBucket.ReadCursor()
+	sk, sv := srcCursor.First()
+
+	// We buffer only the keys of nested sub-buckets (small) so we can recurse
+	// after the streaming read is done; leaf values are compared inline and
+	// never buffered.
+	// Emit progress once per bucket (time-gated inside the logger). This is
+	// essential for bucket-heavy databases: many buckets hold fewer than the
+	// per-key logging threshold, so without a per-bucket call the log would
+	// go silent for a long time and the migration would look hung.
+	m.logVerificationProgress(bucketPath)
+
+	var nestedKeys [][]byte
+	n := 0
+
+	err := targetExt.ForAll(func(tk, tv []byte) error {
+		// Periodically check for cancellation and log progress without
+		// paying the cost on every single key.
+		if n++; n&1023 == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+			m.logVerificationProgress(bucketPath)
+		}
+
+		if sk == nil {
+			return fmt.Errorf("target bucket has extra entries at "+
+				"path %v, extra key %s", bucketPath,
+				loggableKeyName(tk))
+		}
+		if !bytes.Equal(sk, tk) {
+			return fmt.Errorf("key mismatch at path %v: source=%s "+
+				"target=%s", bucketPath, loggableKeyName(sk),
+				loggableKeyName(tk))
+		}
+
+		// We key the nested-vs-leaf decision on the SOURCE value only
+		// (bolt returns a nil value for a nested bucket, a non-nil value
+		// for a leaf), exactly like the cursor path. We must NOT compare
+		// (sv==nil)!=(tv==nil) directly: the sqlite driver decodes an
+		// empty stored value as nil while bolt/postgres return []byte{},
+		// so a legitimate empty-value leaf would otherwise false-fail as
+		// a "type mismatch". bytes.Equal treats nil and empty as equal.
+		if sv == nil {
+			// Source is a nested bucket; the target must be one too,
+			// i.e. it must not carry a (non-nil) value.
+			if tv != nil {
+				return fmt.Errorf("type mismatch at path %v key "+
+					"%s: source is a nested bucket, target is "+
+					"a value", bucketPath, loggableKeyName(sk))
+			}
+
+			kc := make([]byte, len(tk))
+			copy(kc, tk)
+			nestedKeys = append(nestedKeys, kc)
+		} else {
+			if !bytes.Equal(sv, tv) {
+				return fmt.Errorf("value mismatch at path %v key "+
+					"%s, source=%s target=%s", bucketPath,
+					loggableKeyName(sk), loggableKeyName(sv),
+					loggableKeyName(tv))
+			}
+
+			m.verification.persistedState.ProcessedKeys++
+			m.verifiedKeysSinceStart++
+		}
+
+		sk, sv = srcCursor.Next()
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// If the source still has entries, the target is missing some.
+	if sk != nil {
+		return fmt.Errorf("target bucket has fewer entries at path %v, "+
+			"missing key %s", bucketPath, loggableKeyName(sk))
+	}
+
+	// Now recurse into nested buckets (safe: the ForAll read is complete).
+	for _, nk := range nestedKeys {
+		srcNested := srcBucket.NestedReadBucket(nk)
+		if srcNested == nil {
+			return fmt.Errorf("source nested bucket access failed at "+
+				"path %v key %s", bucketPath, loggableKeyName(nk))
+		}
+		targetNested := targetExt.NestedReadBucket(nk)
+		if targetNested == nil {
+			return fmt.Errorf("target nested bucket access failed at "+
+				"path %v key %s", bucketPath, loggableKeyName(nk))
+		}
+
+		newPath := bucketPath.AppendBucket(nk)
+		targetNestedExt, ok := targetNested.(kvdb.ExtendedRBucket)
+		if !ok {
+			return fmt.Errorf("target nested bucket does not support "+
+				"ForAll at path %v", newPath)
+		}
+
+		if err := m.walkAndCompareForAll(
+			ctx, srcNested, targetNestedExt, newPath,
+		); err != nil {
+			return err
+		}
+
+		m.verification.persistedState.ProcessedBuckets++
+	}
+
+	return nil
+}
+
+// walkAndCompareCursor walks source and target buckets in parallel, comparing
+// their contents one key at a time via cursors. This is the resume-capable and
+// bolt-compatible fallback used when the streaming ForAll path is disabled.
+func (m *Migrator) walkAndCompareCursor(ctx context.Context, srcBucket,
 	targetBucket kvdb.RBucket, bucketPath BucketPath) error {
 
 	currentPath := m.verification.persistedState.CurrentBucketPath
@@ -802,6 +974,10 @@ func (m *Migrator) walkAndCompare(ctx context.Context, srcBucket,
 	case false:
 		m.cfg.Logger.Debugf("Walking and comparing bucket: %v",
 			bucketPath)
+
+		// Emit progress once per bucket (time-gated) so bucket-heavy
+		// databases don't appear hung. See walkAndCompareForAll.
+		m.logVerificationProgress(bucketPath)
 
 		// Check the sequence number of the source and target buckets.
 		if srcBucket.Sequence() != targetBucket.Sequence() {

--- a/migratekvdb/state.go
+++ b/migratekvdb/state.go
@@ -33,6 +33,15 @@ type persistedState struct {
 
 	// FinishedTime is the time when the verification is finished.
 	FinishedTime time.Time `json:"finished_time"`
+
+	// BulkInProgress is set to true by the bulk (batched) migration path
+	// after it has begun writing to the target but before it has confirmed
+	// completion. Because the target (SQL) and this meta DB (bolt) cannot
+	// share a transaction, this flag lets a re-run detect that a previous
+	// bulk attempt may have partially (or fully) committed to the target
+	// and safely recover by truncating and restarting, rather than getting
+	// stuck on the non-empty-target guard.
+	BulkInProgress bool `json:"bulk_in_progress"`
 }
 
 // String returns a string representation of the persisted state.

--- a/migratekvdb/verify_batched.go
+++ b/migratekvdb/verify_batched.go
@@ -1,0 +1,411 @@
+package migratekvdb
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/lightningnetwork/lnd/channeldb"
+	"github.com/lightningnetwork/lnd/kvdb"
+)
+
+// DefaultVerifyBatchSize is the number of buckets whose direct children are
+// fetched in a single query during batched verification.
+const DefaultVerifyBatchSize = 2000
+
+// MaxVerifyBatchSize caps the batch so the constructed id-array literal stays
+// reasonable.
+const MaxVerifyBatchSize = 20000
+
+// vFrontier is a bucket pending verification: its source handle, its target row
+// id, and its path (for error messages / progress).
+type vFrontier struct {
+	src  kvdb.RBucket
+	id   int64
+	path BucketPath
+}
+
+// VerifyBatchedSQL verifies a bolt source against a SQL target using
+// breadth-first, batched child fetches. The direct children of up to batchSize
+// buckets are read in one query (WHERE parent_id = ANY(...)), instead of one
+// query per bucket. This collapses the ~2-3 round-trips per bucket that
+// dominate on bucket-heavy databases into ~total_buckets/batchSize queries,
+// while keeping every query a plain index scan on (parent_id, key): no
+// server-side sort, no work_mem blow-up, and O(level) client memory.
+//
+// The batch result is streamed and compared against each parent's source cursor
+// inline, so a batch that happens to include a very wide bucket does not buffer
+// all of its rows in memory.
+//
+// It is a fresh-only verification for a SQL target reached via a *sql.DB (pgx
+// driver). The hierarchical ForAll/cursor path (VerifyMigration) remains for
+// bolt targets and for resume.
+func (m *Migrator) VerifyBatchedSQL(ctx context.Context, sourceDB kvdb.Backend,
+	db *sql.DB, table string, batchSize int) error {
+
+	switch {
+	case batchSize <= 0:
+		batchSize = DefaultVerifyBatchSize
+	case batchSize > MaxVerifyBatchSize:
+		batchSize = MaxVerifyBatchSize
+	}
+
+	m.startTimeVerification = time.Now()
+	m.cfg.Logger.Infof("Batched verification of db with prefix `%s` from "+
+		"table `%s` (batch size %d)", m.cfg.DBPrefixName, table, batchSize)
+
+	// We need the finished migration state for the final count cross-check.
+	if err := m.migration.read(); err != nil {
+		return fmt.Errorf("failed to read migration state: %w", err)
+	}
+	if !m.migration.persistedState.Finished {
+		return fmt.Errorf("migration not finished; refusing to verify")
+	}
+
+	// Batched verification always runs fresh.
+	m.verification.persistedState = newPersistedState()
+
+	// Run every target read inside a single read-only, repeatable-read
+	// transaction so all queries observe one consistent snapshot (matching
+	// the snapshot semantics of the kvdb.View path). It also keeps the whole
+	// verification on one connection, so the prepared statement is reused.
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{
+		ReadOnly:  true,
+		Isolation: sql.LevelRepeatableRead,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to begin read transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	err = sourceDB.View(func(stx kvdb.RTx) error {
+		// Bootstrap: match source top-level buckets to target top-level
+		// rows (parent_id IS NULL).
+		topByKey, err := m.fetchTopLevel(ctx, tx, table)
+		if err != nil {
+			return err
+		}
+
+		var level []vFrontier
+		srcRoots := make(map[string]struct{}, len(topByKey))
+		err = stx.ForEachBucket(func(name []byte) error {
+			// Skip the tombstone marker, mirroring the original verify.
+			if bytes.Equal(name, channeldb.TombstoneKey) {
+				return nil
+			}
+
+			src := stx.ReadBucket(name)
+			if src == nil {
+				return fmt.Errorf("source root bucket missing: %s",
+					loggableKeyName(name))
+			}
+
+			tr, ok := topByKey[string(name)]
+			if !ok {
+				return fmt.Errorf("root bucket missing in target: "+
+					"%s", loggableKeyName(name))
+			}
+			if tr.value != nil {
+				return fmt.Errorf("type mismatch at root %s: source "+
+					"is a bucket, target is a value",
+					loggableKeyName(name))
+			}
+			if src.Sequence() != uint64(tr.seq) {
+				return fmt.Errorf("sequence mismatch at root %s: "+
+					"source=%d target=%d", loggableKeyName(name),
+					src.Sequence(), tr.seq)
+			}
+
+			srcRoots[string(name)] = struct{}{}
+			m.verification.persistedState.ProcessedBuckets++
+			level = append(level, vFrontier{
+				src:  src,
+				id:   tr.id,
+				path: NewBucketPath([][]byte{name}),
+			})
+
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		// Assert the target has no extra top-level buckets beyond the
+		// source's. This is safe (and not done by the sqlite-combining
+		// compareDBs path) because each namespace has its own table in
+		// postgres, so a stray top-level row here is real corruption. The
+		// tombstone marker, if present, is not a source bucket and is
+		// ignored.
+		for k := range topByKey {
+			if _, ok := srcRoots[k]; ok {
+				continue
+			}
+			if bytes.Equal([]byte(k), channeldb.TombstoneKey) {
+				continue
+			}
+			return fmt.Errorf("target has an unexpected top-level "+
+				"bucket not present in source: %s",
+				loggableKeyName([]byte(k)))
+		}
+
+		// Breadth-first, one level at a time, batching the child fetches.
+		for len(level) > 0 {
+			var next []vFrontier
+			for start := 0; start < len(level); start += batchSize {
+				end := start + batchSize
+				if end > len(level) {
+					end = len(level)
+				}
+
+				subs, err := m.verifyBatch(
+					ctx, tx, table, level[start:end],
+				)
+				if err != nil {
+					return err
+				}
+				next = append(next, subs...)
+			}
+			level = next
+		}
+
+		return nil
+	}, func() {})
+	if err != nil {
+		return err
+	}
+
+	// Cross-check counts against the migration, exactly like VerifyMigration.
+	if m.migration.persistedState.ProcessedKeys !=
+		m.verification.persistedState.ProcessedKeys {
+
+		return fmt.Errorf("processed keys mismatch: migration=%d "+
+			"verification=%d", m.migration.persistedState.ProcessedKeys,
+			m.verification.persistedState.ProcessedKeys)
+	}
+	if m.migration.persistedState.ProcessedBuckets !=
+		m.verification.persistedState.ProcessedBuckets {
+
+		return fmt.Errorf("processed buckets mismatch: migration=%d "+
+			"verification=%d",
+			m.migration.persistedState.ProcessedBuckets,
+			m.verification.persistedState.ProcessedBuckets)
+	}
+
+	m.verification.setFinalState()
+	if err := m.verification.write(); err != nil {
+		return err
+	}
+
+	m.logFinalStats()
+
+	return nil
+}
+
+// fetchTopLevel returns the target's top-level (parent_id IS NULL) rows keyed by
+// their key.
+func (m *Migrator) fetchTopLevel(ctx context.Context, tx *sql.Tx,
+	table string) (map[string]vChild, error) {
+
+	rows, err := tx.QueryContext(ctx, "SELECT key, value, sequence, id "+
+		"FROM "+table+" WHERE parent_id IS NULL ORDER BY key")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]vChild)
+	for rows.Next() {
+		var c vChild
+		var seq sql.NullInt64
+		if err := rows.Scan(&c.key, &c.value, &seq, &c.id); err != nil {
+			return nil, err
+		}
+		if seq.Valid {
+			c.seq = seq.Int64
+		}
+		out[string(c.key)] = c
+	}
+
+	return out, rows.Err()
+}
+
+// vChild is a single target row (used for top-level bootstrap).
+type vChild struct {
+	key   []byte
+	value []byte // nil => sub-bucket
+	seq   int64
+	id    int64
+}
+
+// verifyBatch fetches the direct children of every bucket in batch with a single
+// query and compares them, streaming, against each bucket's source cursor. It
+// returns the sub-buckets discovered (the next BFS level).
+func (m *Migrator) verifyBatch(ctx context.Context, tx *sql.Tx, table string,
+	batch []vFrontier) ([]vFrontier, error) {
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	byID := make(map[int64]vFrontier, len(batch))
+	var ids strings.Builder
+	ids.WriteByte('{')
+	for i, it := range batch {
+		if i > 0 {
+			ids.WriteByte(',')
+		}
+		ids.WriteString(strconv.FormatInt(it.id, 10))
+		byID[it.id] = it
+	}
+	ids.WriteByte('}')
+
+	// Constant SQL (single bound array param) => one prepared statement
+	// reused for every batch, so pgx's statement cache is not defeated.
+	rows, err := tx.QueryContext(ctx, "SELECT parent_id, key, value, "+
+		"sequence, id FROM "+table+" WHERE parent_id = ANY($1::bigint[]) "+
+		"ORDER BY parent_id, key", ids.String())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var subs []vFrontier
+	seen := make(map[int64]bool, len(batch))
+
+	// Streaming state for the bucket currently being compared.
+	var (
+		curPID  int64 = -1
+		curItem vFrontier
+		curCur  kvdb.RCursor
+		sk, sv  []byte
+		haveCur bool
+	)
+
+	finalize := func() error {
+		if !haveCur {
+			return nil
+		}
+		// Source must be exhausted; any leftover source key is missing
+		// from the target.
+		if sk != nil {
+			return fmt.Errorf("target bucket has fewer entries at "+
+				"path %v, missing key %s", curItem.path,
+				loggableKeyName(sk))
+		}
+		m.logVerificationProgress(curItem.path)
+
+		return nil
+	}
+
+	for rows.Next() {
+		var (
+			pid, cid int64
+			tk, tv   []byte
+			seq      sql.NullInt64
+		)
+		if err := rows.Scan(&pid, &tk, &tv, &seq, &cid); err != nil {
+			return nil, err
+		}
+
+		if pid != curPID {
+			if err := finalize(); err != nil {
+				return nil, err
+			}
+			it, ok := byID[pid]
+			if !ok {
+				return nil, fmt.Errorf("unexpected parent_id %d "+
+					"in batch result", pid)
+			}
+			curPID, curItem, haveCur = pid, it, true
+			seen[pid] = true
+			curCur = it.src.ReadCursor()
+			sk, sv = curCur.First()
+		}
+
+		if sk == nil {
+			return nil, fmt.Errorf("target bucket has extra entries "+
+				"at path %v, extra key %s", curItem.path,
+				loggableKeyName(tk))
+		}
+		if !bytes.Equal(sk, tk) {
+			return nil, fmt.Errorf("key mismatch at path %v: "+
+				"source=%s target=%s", curItem.path,
+				loggableKeyName(sk), loggableKeyName(tk))
+		}
+
+		if sv == nil {
+			// Source is a nested bucket; target must be one too.
+			if tv != nil {
+				return nil, fmt.Errorf("type mismatch at path %v "+
+					"key %s: source is a nested bucket, "+
+					"target is a value", curItem.path,
+					loggableKeyName(sk))
+			}
+
+			srcNested := curItem.src.NestedReadBucket(sk)
+			if srcNested == nil {
+				return nil, fmt.Errorf("source nested bucket "+
+					"access failed at path %v key %s",
+					curItem.path, loggableKeyName(sk))
+			}
+			var s int64
+			if seq.Valid {
+				s = seq.Int64
+			}
+			if srcNested.Sequence() != uint64(s) {
+				return nil, fmt.Errorf("sequence mismatch at path "+
+					"%v key %s: source=%d target=%d",
+					curItem.path, loggableKeyName(sk),
+					srcNested.Sequence(), s)
+			}
+
+			kc := make([]byte, len(sk))
+			copy(kc, sk)
+			subs = append(subs, vFrontier{
+				src:  srcNested,
+				id:   cid,
+				path: curItem.path.AppendBucket(kc),
+			})
+			m.verification.persistedState.ProcessedBuckets++
+		} else {
+			// Leaf: compare values. We deliberately do NOT log values
+			// in the error to avoid exposing content.
+			if !bytes.Equal(sv, tv) {
+				return nil, fmt.Errorf("value mismatch at path %v "+
+					"key %s", curItem.path, loggableKeyName(sk))
+			}
+			m.verification.persistedState.ProcessedKeys++
+			m.verifiedKeysSinceStart++
+		}
+
+		sk, sv = curCur.Next()
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if err := finalize(); err != nil {
+		return nil, err
+	}
+
+	// Any batched bucket with no rows returned must be empty on the source
+	// side too.
+	for _, it := range batch {
+		if seen[it.id] {
+			continue
+		}
+		if k, _ := it.src.ReadCursor().First(); k != nil {
+			return nil, fmt.Errorf("target bucket is empty but "+
+				"source is not at path %v, missing key %s",
+				it.path, loggableKeyName(k))
+		}
+		m.logVerificationProgress(it.path)
+	}
+
+	return subs, nil
+}


### PR DESCRIPTION
## Background

Migrating an lnd bolt database (for example channel.db) into postgres is very slow. We measured about 4.5 hours for ~15M keys. Profiling showed the process was almost entirely idle waiting on the network (CPU around 6 percent), not busy doing work.

The cause is that the migration talks to postgres one row at a time, and it does so twice. The migrate phase issues one INSERT per key, and the verify phase reads the target back one query at a time. Each of those is a separate round trip on a single connection, so total time is roughly `round_trips * round_trip_latency`, where `round_trips` scales with the number of keys and buckets. It scales linearly with database size and with network latency, which is why co-locating the DB helps a little but does not fix the underlying problem.

This PR reduces the number of round trips in both the migrate and verify phases.

## Changes

1. Batched write path (`migratekvdb/bulk.go`, new `MigrateBulkSQL`)

Adds a postgres write path that inserts leaf rows in batches (1000 rows per statement by default) using a raw pgx transaction, instead of one Put per key through kvdb. It walks the source depth first, creates bucket rows as it goes so the parent_id foreign key is always satisfied, and streams leaf key/values into multi-row INSERTs. The whole migration runs in a single transaction. It does not modify or fork the kvdb dependency.

This path is for fresh migrations only. The existing Migrate still handles resume.

Because the SQL target and the bolt meta database cannot share a transaction, completion is not perfectly atomic across the two. To make an interrupted run recoverable instead of leaving it stuck, `MigrateBulkSQL` writes an in-progress marker to the meta DB before it starts writing data, and clears it after the SQL commit and the finished-state write. On a re-run, if the marker is still set, it truncates the target table and starts over, which is safe because the marker means the previous attempt owned the table. This adds two small meta writes and no measurable overhead on the hot path.

Batch size is clamped to 65535 / 3 rows so a caller cannot exceed the postgres `bind-parameter` limit.

2. Streaming verification and progress logging (`migratekvdb/migration.go`)

Two changes to the existing verify path:

- The fresh-verification path now reads each target bucket with a single ForAll query instead of a per-key cursor, and compares it in lockstep against the source cursor. Nested buckets are collected during the streamed read and recursed into afterward, since ForAll does not allow issuing queries from inside its callback. This applies to fresh verifications against a backend that implements kvdb.ExtendedRBucket (postgres and sqlite). Resume and bolt targets keep using the original per-key cursor path, which is unchanged apart from a rename.
- Progress is now logged once per bucket (time-gated), in both migrate and verify. Previously the log fired only every N keys within a single bucket, so on a database with many small buckets it went silent for a long time and the process looked hung even though it was making progress.

3. Batched verification (`migratekvdb/verify_batched.go`, new `VerifyBatchedSQL`)

The single-ForAll-per-bucket verify above still issues a few queries per bucket, so on a database with a very large number of buckets (a real channel.db has on the order of a million) the verify phase is dominated by per-bucket round trips.

`VerifyBatchedSQL` walks the tree breadth first and fetches the direct children of up to `batchSize` buckets in one query (WHERE parent_id = ANY(...)), instead of one query per bucket. That reduces the query count from roughly `bucket_count` to roughly `bucket_count / batchSize`. The batch result is streamed `(ORDER BY parent_id, key)` and compared against each parent's source cursor inline, so a batch that happens to include a very wide bucket does not buffer that bucket's rows in memory. Every query is a plain index scan on `(parent_id, key)`, so there is no server-side sort and no `work_mem` pressure, and client memory is bounded by one BFS level. The `parent_id` array is passed as a single bound parameter so the SQL text is constant and pgx reuses one prepared statement. Verification error messages print keys and paths only, never values.

This is a fresh-only path for a postgres target reached through a raw `*sql.DB`. Bolt targets and resume continue to use the hierarchical path.

4. CLI wiring (`cmd_migrate_db.go`)

A new `--bulk-writes` flag enables the fast postgres path for a fresh migration: `MigrateBulkSQL` for the migrate phase and `VerifyBatchedSQL` for the verify phase. It is opt-in and postgres only. Any other destination logs a warning and falls back to the standard `Migrate` and `VerifyMigration` path. A prior interrupted bulk run self-recovers as described above; a prior interrupted non-bulk run that already wrote data will surface a "target not empty" error rather than silently proceeding.

## Results

We ran the actual lndinit migrate-db `--bulk-writes` command end to end against a copy of a real mainnet data directory.

- Full command, all mandatory databases, completed successfully in 8m12s.
- channeldb verify: 21m50s with the single-ForAll-per-bucket path, 1m22s with the batched path (about 16x), byte for byte identical both times.

The dominant remaining cost is bucket creation during the migrate phase, which still issues one INSERT ... RETURNING id per bucket. Batching that is a sensible follow-up but is out of scope here.

One behavior change worth calling out: a fresh sqlite or postgres verify no longer checkpoints mid-bucket, so if it is interrupted while verifying a large top-level bucket, the resume re-verifies that bucket from the start. Resume correctness is preserved, only repeated work changes. Bolt was never on this path.

## Testing

New: an edge-case source builder (empty values, binary keys, prefix-overlapping keys, explicit sequences, an empty bucket, three-level nesting with leaves and sub-buckets interleaved) plus an independent byte-for-byte comparator.

A sqlite test verifies the empty-value handling (regression test for the nil-versus-empty case, where sqlite decodes an empty stored value as nil while bolt and postgres return an empty slice). A postgres test covers bulk migrate correctness, batch-size clamping, refusal on a non-empty target, crash recovery via the in-progress marker, batched verification (including a small batch size to exercise batch and level boundaries), and negative cases confirming both verify paths detect a missing row, a mutated value, and an extra row. An end-to-end test runs the full command with `--bulk-writes`. All pass under the base, kvdb_sqlite, and kvdb_postgres tags.