### PR TITLE
version: bump to v0.1.37-beta

### DIFF
--- a/version.go
+++ b/version.go
@@ -32,7 +32,7 @@ const (
 	AppMinor uint = 1
 
 	// AppPatch defines the application patch for this binary.
-	AppPatch uint = 36
+	AppPatch uint = 37
 
 	// AppPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Problem

Production runs the Vault KV v2 support from #92, but that code has no release tag. The current `v0.1.36-beta` release predates Vault support. This prevents the normal Docker release workflow from building a Vault-capable image on a newer LND base.

## Change

Bump lndinit to `v0.1.37-beta` after #92.

Once this PR and #92 are on `main`, the normal release tags can publish:

```text
v0.1.37-beta
docker/v0.1.37-beta-lnd-v0.21.2-beta
```

The Docker workflow will then check out the Vault-capable `v0.1.37-beta` source and use the official `lightninglabs/lnd:v0.21.2-beta` base. No special `-vault` base image or manual build is needed.

## Scope

- Changes only the reported lndinit patch version.
- Does not change the Vault implementation.
- Does not change LND dependencies or runtime behavior.
- Depends on #92.

## Test

- `go test ./...`
- Local image built from the #92 Vault source on `lightninglabs/lnd:v0.21.2-beta`.
- Image reports LND and lncli `v0.21.2-beta`.
- Image exposes lndinit's Vault KV v2 flags.
